### PR TITLE
Fix nil pointer dereference panic on TCP reqs

### DIFF
--- a/server.go
+++ b/server.go
@@ -39,7 +39,6 @@ func (h *Handler) Handle(response dns.ResponseWriter, req *dns.Msg) {
             }
         }
 
-        response.Close()
         debugMsg("Sent response to ", response.RemoteAddr())
     })
 }


### PR DESCRIPTION
Calling `Close()` closes the tpc socket, but the underlying lib is still expecting it to be open so it can [do some retry logic](https://github.com/miekg/dns/blob/5c48f3623a4b2f1465b8ccf4fe29b6eb3888ee07/server.go#L332-L356)

We either need to call `response.Hijack()` early – to let the underlying lib know that we're planning on handling `Close()` ourselves – or we need to just let it do its thing.

I've opted to leave it up to the lib completely, so it can do it's retry stuff if that's ever useful.
