### PR TITLE
Include the hostname in graphite metrics

### DIFF
--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
     "runtime"
     "time"
     "net"
+    "strings"
 )
 
 var (
@@ -53,7 +54,15 @@ func main() {
             logger.Fatalf("Failed to parse graphite server: ", err)
         }
 
-        go metrics.Graphite(metrics.DefaultRegistry, time.Duration(Options.GraphiteDuration) * time.Second, "discodns", addr)
+        prefix := "discodns"
+        hostname, err := os.Hostname()
+        if err != nil {
+            logger.Fatalf("Unable to get hostname: ", err)
+        }
+
+        prefix = prefix + "." + strings.Replace(hostname, ".", "_", -1)
+
+        go metrics.Graphite(metrics.DefaultRegistry, time.Duration(Options.GraphiteDuration) * time.Second, prefix, addr)
     } else if Options.MetricsDuration > 0 {
         go metrics.Log(metrics.DefaultRegistry, time.Duration(Options.MetricsDuration) * time.Second, logger)
 


### PR DESCRIPTION
This is a fix for #19. Example graphite metrics...

```
discodns.Toms-MacBook-Pro-2_local.request.handler.tcp.response_time.50-percentile 0.00 1406848500
discodns.Toms-MacBook-Pro-2_local.request.handler.tcp.response_time.75-percentile 0.00 1406848500
discodns.Toms-MacBook-Pro-2_local.request.handler.tcp.response_time.95-percentile 0.00 1406848500
discodns.Toms-MacBook-Pro-2_local.request.handler.tcp.response_time.99-percentile 0.00 1406848500
discodns.Toms-MacBook-Pro-2_local.request.handler.tcp.response_time.999-percentile 0.00 1406848500
```
