### PR TITLE
Syncronous update locking

### DIFF
--- a/lock.go
+++ b/lock.go
@@ -1,80 +1,151 @@
 package main
 
 import (
+    "code.google.com/p/go-uuid/uuid"
+    "errors"
     "github.com/coreos/go-etcd/etcd"
+    "time"
 )
 
-type DomainLock struct {
-    etcd        *etcd.Client
-    etcdPrefix  string
-    domain      string
-    index       uint64
-    lockPath    string
-    lockExpiry  uint64
+const (
+    ETCD_LOCK_TTL       = 10
+    ETCD_LOCK_HEARTBEAT = 5
+)
+
+// EtcdKeyLock represents a lock on a single key. Its semantics: once asked to
+// Acquire, it will try to grab hold of the key in etcd, if it doesnt exist.
+// If it does exist, then the lock waits for the other party to release it.
+// Once Acquired, it will hold on to the lock indefinitely until Abandoned
+type EtcdKeyLock struct {
+    uuid       string
+    key        string
+    etcdClient *etcd.Client
+    killChan   chan bool
+    killed     bool
 }
 
-func (l *DomainLock) Lock(shouldPanic bool) error {
-    if l.index > 0 || l.lockPath != "" {
-        return nil
-    }
+func NewEtcdKeyLock(etcdClient *etcd.Client, key string) *EtcdKeyLock {
+    uuid := uuid.New()
+    return &EtcdKeyLock{uuid: uuid, key: key, etcdClient: etcdClient, killChan: make(chan bool)}
+}
 
-    l.lockPath = l.etcdPrefix + nameToKey(l.domain, "/._UPDATE_LOCK")
-    debugMsg("Locking " + l.domain + " at " + l.lockPath)
-
-    response, err := l.etcd.Create(l.lockPath, "", l.lockExpiry)
-    if err != nil {
-        debugMsg("Failed to acquire lock on domain " + l.domain)
-        debugMsg(err)
-
-        if shouldPanic {
-            panic("Failed to acquire lock on domain " + l.domain)
+// Start the process of trying to acquire a key lock. Returns a channel that
+// will be sent true when the lock is aquired then closed. Callers can use this
+// as their signal to proceed. The lock will kept indefinitely until abandoned.
+func (l *EtcdKeyLock) Acquire() chan bool {
+    inner_acq := make(chan bool)
+    acquired := make(chan bool)
+    go func() {
+        _, ok := <-inner_acq
+        if ok {
+            acquired <- true
+            go heartbeat(l, nil)
+            go removeWhenCancelled(l)
         }
-
-        return err
-    }
-
-    l.index = response.Node.CreatedIndex
-    return nil
+        close(acquired)
+    }()
+    go tryCreate(l, inner_acq)
+    return acquired
 }
 
-func (l *DomainLock) Unlock(shouldPanic bool) error {
-    debugMsg("Unlocking " + l.domain + " from " + l.lockPath)
+// Abandons the lock. This just means closing the internal cancellation
+// channel, causing all the child goros to do whatever they need to do.
+func (l *EtcdKeyLock) Abandon() {
+    if !l.killed {
+        l.killed = true
+        close(l.killChan)
+    }
+}
 
-    _, err := l.etcd.CompareAndDelete(l.lockPath, "", l.index)
-    if err != nil {
-        debugMsg("Failed to unlock domain " + l.domain)
-        debugMsg(err)
+// Blocking version of Acquire, hiding the channels from callers who just want
+// to synchronously wait
+func (l *EtcdKeyLock) WaitForAcquire(timeout int) (bool, error) {
+    timeoutKiller := time.AfterFunc(time.Duration(timeout) * time.Second, func(){
+        l.Abandon()
+    })
+    acq := l.Acquire()
+    ok, open := <- acq
+    if ok && open {
+        stopped := timeoutKiller.Stop()
+        // Stopped == false means the timer already fired: this shouldn't be
+        // possible (we shouldn't have been able to get an OK message in that
+        // case). Erroring mostly out of paranoia: I'm positive this race can't
+        // happen (famous last words though)
+        if !stopped {
+            return false, errors.New("Acquired a lock that was also killed by a timeout: this should not be possible!")
+        }
+        return true, nil
+    } else {
+        return false, errors.New("Couldn't aqcuire lock in time")
+    }
+}
 
-        if shouldPanic {
-            panic("Failed to unlock domain " + l.domain)
+// The internals of trying to get a lock: Try to PUT to the lock key iff it
+// doesn't exist. If that suceeds, the lock is owned; signal the chan and
+// return. If it fails, watch the etcd key until it changes. When it does
+// change, try again. Repeat indefinitely until cancelled.
+func tryCreate(l *EtcdKeyLock, acq chan bool) {
+    defer close(acq)
+    for {
+        select {
+        case _, chOpen := <-l.killChan:
+            if !chOpen {
+                return
+            }
+        default:
+            _, err := l.etcdClient.Create(l.key, l.uuid, ETCD_LOCK_TTL)
+            if err == nil {
+                acq <- true
+                return
+            } else {
+                err, cast := err.(*etcd.EtcdError)
+                if cast && err.ErrorCode == 105 {
+                    // Watch until it changes. (The current index is given to
+                    // make sure we don't miss any changes in between)
+                    _, err := l.etcdClient.Watch(l.key, err.Index+1, false, nil, l.killChan)
+                    if err == nil {
+                        // Skip the sleep and attempt a retry asap
+                        continue
+                    }
+                }
+                // if not created and not watching, pause briefly
+                time.Sleep(1 * time.Second)
+            }
         }
     }
-
-    return err
 }
 
-// IsLocked will return true if the lock is still acquired by this instance
-// Since locks may have an expiry, it is possible for the lock to expire and be
-// acquired by another party
-func (l *DomainLock) IsLocked() (locked bool) {
-    locked = false
-
-    // Verify that the domain is locked and that it's *our* lock
-    if l.lockPath != "" {
-        response, err := l.etcd.Get(l.lockPath, false, false)
-        if err == nil {
-            locked = response.Node.CreatedIndex == l.index
+func heartbeat(l *EtcdKeyLock, ping chan bool) {
+    if ping == nil {
+        ping = make(chan bool)
+    }
+    defer close(ping)
+    for {
+        time.Sleep(ETCD_LOCK_HEARTBEAT * time.Second)
+        select {
+        case _, chOpen := <-l.killChan:
+            if !chOpen {
+                return
+            }
+        default:
+            _, err := l.etcdClient.Set(l.key, l.uuid, ETCD_LOCK_TTL)
+            // non-blocking write on the ping channel
+            select {
+            case ping <- (err == nil):
+            default:
+            }
         }
     }
-
-    return
 }
 
-// lockDomain will lock the given domain in the given etcd cluster, and return
-// the DomainLock struct pre-populated such that calling Domain Unlock()
-// will release the lock.
-func lockDomain(etcd *etcd.Client, domain string, etcdPrefix string) (lock *DomainLock) {
-    lock = &DomainLock{etcd: etcd, domain: domain, lockExpiry: 30, etcdPrefix: etcdPrefix}
-    defer lock.Lock(true)
-    return lock
+func removeWhenCancelled(l *EtcdKeyLock) {
+    defer func() {
+        l.etcdClient.CompareAndDelete(l.key, l.uuid, 0)
+    }()
+    for {
+        _, chOpen := <-l.killChan
+        if !chOpen {
+            return
+        }
+    }
 }

--- a/lock_test.go
+++ b/lock_test.go
@@ -1,5 +1,32 @@
 package main
 
-// import (
-//     "testing"
-// )
+import (
+    "testing"
+    "time"
+)
+
+func TestSimpleLockUnlock(t *testing.T) {
+    testKey := "TestSimpleLockUnlock/.lock"
+    client.Delete(testKey, true)
+
+    lock := NewEtcdKeyLock(client, testKey)
+    locked, err := lock.WaitForAcquire(1)
+
+    if !locked || err != nil {
+        t.Error("Expected to acquire lock, failed")
+        t.Fatal()
+    }
+    _, err = client.Get(testKey, false, true)
+    if err != nil {
+        t.Error("Lock claimed to succeed but etcd record missing/broken")
+        t.Fatal()
+    }
+
+    lock.Abandon()
+    time.Sleep(500 * time.Millisecond)
+    _, err = client.Get(testKey, false, true)
+    if err == nil {
+        t.Error("Lock abandoned, but key exists")
+        t.Fatal()
+    }
+}

--- a/lock_test.go
+++ b/lock_test.go
@@ -1,52 +1,5 @@
 package main
 
-import (
-    "testing"
-)
-
-func TestLock(t *testing.T) {
-    // Enable debug logging
-    log_debug = true
-}
-
-func TestSimpleLockUnlock(t *testing.T) {
-    client.Delete("TestSimpleLockUnlock/", true)
-
-    lock := lockDomain(client, "discodns.net", "TestSimpleLockUnlock")
-
-    if lock.IsLocked() != true {
-        t.Error("Expected lock to be locked, it was not")
-        t.Fatal()
-    }
-
-    lock.Unlock(false)
-
-    if lock.IsLocked() != false {
-        t.Error("Expected lock to be unlocked, it was not")
-        t.Fatal()
-    }
-
-}
-
-func TestConflictingLock(t *testing.T) {
-    client.Delete("TestConflictingLock/", true)
-
-    lockA := lockDomain(client, "discodns.net", "TestConflictingLock/")
-    if lockA.IsLocked() != true {
-        t.Error("Expected lock to be locked, it was not")
-        t.Fatal()
-    }
-
-    // Defer a function to handle the panic when we request overlapping
-    // locks. We do this here because if the lock fails to be acquired above
-    // the test should fail exceptionally.
-    defer func() {
-        p := recover()
-        if p == nil {
-            t.Error("Expected a panic, got nil")
-            t.Fatal()
-        }
-    }()
-
-    lockDomain(client, "discodns.net", "TestConflictingLock/")
-}
+// import (
+//     "testing"
+// )

--- a/update.go
+++ b/update.go
@@ -36,8 +36,7 @@ func (u *DynamicUpdateManager) Update(zone string, req *dns.Msg) (msg *dns.Msg) 
         }
     }
 
-    // Ensure we recover from any panicking goroutine, this helps ensure we don't
-    // leave any acquired locks around if possible
+    // Ensure we recover from any panicking goroutine
     defer func() {
         if r := recover(); r != nil {
             debugMsg("[PANIC] " + fmt.Sprint(r))
@@ -45,14 +44,20 @@ func (u *DynamicUpdateManager) Update(zone string, req *dns.Msg) (msg *dns.Msg) 
         }
     }()
 
-    // Attempt to acquire a lock on all of the domains referenced in the update
-    // If any lock attempt fails, all acquired locks will be released and no
-    // update will be applied.
-    for _, rrs := range rrsets {
-        for _, rr := range rrs {
-            lock := lockDomain(u.etcd, rr.Header().Name, u.etcdPrefix)
-            defer lock.Unlock(true)
-        }
+    // Attempt to acquire the dns-updates lock key.
+    // TODO (orls): This means all updates from all running instances are
+    // applied fully serially; this is less than ideal, the spec says they
+    // should be serial only when conflicting with one another. But...this is
+    // easier than building full transactions isolation mgmt :) For a low
+    // frequency of updates, this should fine.
+    lock := NewEtcdKeyLock(u.etcd, u.etcdPrefix + "._DISCODNS_UPDATE_LOCK")
+    defer lock.Abandon()
+    // block until locked or timed-out
+    _, err := lock.WaitForAcquire(30)
+    if err != nil {
+        debugMsg("Failed to acquire or keep the update lock: ", err)
+        msg.SetRcode(req, dns.RcodeServerFailure)
+        return
     }
 
     // Validate the prerequisites of the update, returning immediately if they


### PR DESCRIPTION
Apply all update operations, systemwide, serially, by acquiring (or waiting to acquire) a single lock key in etcd.

The lock is implemented as a key with a short TTL, so that rogue/crashed processes can't cause a stale lock. For as long as a process holds a lock, the lock code keeps re-creating it for as long as it is ''alive"

Calling code must take care to Abandon the lock no matter what. If a handler goroutine dies, without abandoning the lock and without taking the whole process down, the lock will be held indefinitely.