### PR TITLE
Simplify the lookup flow to avoid races

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ compile:
 
 test:
 	@echo "\033[34m●\033[39m Running tests"
-	go test
+	go test -race
 	@echo "\033[32m✔\033[39m Tests passed"
 
 install:

--- a/resolver.go
+++ b/resolver.go
@@ -301,6 +301,10 @@ func (r *Resolver) AnswerQuestion(q dns.Question) (answers chan dns.RR, errors c
                 }
             }
         }()
+    } else {
+        // nothing we can do
+        close(answers)
+        close(errors)
     }
 
     return answers, errors

--- a/resolver.go
+++ b/resolver.go
@@ -152,7 +152,7 @@ func (r *Resolver) Lookup(req *dns.Msg) (msg *dns.Msg) {
 
     if q.Qclass == dns.ClassINET {
         aChan, eChan = r.AnswerQuestion(q)
-        answers, errors = chansGather(aChan, eChan)
+        answers, errors = gatherFromChannels(aChan, eChan)
     }
 
     errored = errored || len(errors) > 0
@@ -169,7 +169,7 @@ func (r *Resolver) Lookup(req *dns.Msg) (msg *dns.Msg) {
                     Qclass: q.Qclass}
 
                 aChan, eChan = r.AnswerQuestion(question)
-                answers, errors = chansGather(aChan, eChan)
+                answers, errors = gatherFromChannels(aChan, eChan)
 
                 errored = errored || len(errors) > 0
                 if len(answers) > 0 {
@@ -207,8 +207,9 @@ func (r *Resolver) Lookup(req *dns.Msg) (msg *dns.Msg) {
     return
 }
 
-
-func chansGather(rrsIn chan dns.RR, errsIn chan error) (rrs []dns.RR, errs []error) {
+// Gather up results from answer and error channels into slices. Waits for the
+// channels to be closed before returning.
+func gatherFromChannels(rrsIn chan dns.RR, errsIn chan error) (rrs []dns.RR, errs []error) {
     rrs = []dns.RR{}
     errs = []error{}
     done := 0

--- a/resolver.go
+++ b/resolver.go
@@ -151,7 +151,7 @@ func (r *Resolver) Lookup(req *dns.Msg) (msg *dns.Msg) {
     var eChan chan error
 
     if q.Qclass == dns.ClassINET {
-        aChan, eChan = r.AnswerQuestion(q, true)
+        aChan, eChan = r.AnswerQuestion(q)
         answers, errors = chansGather(aChan, eChan)
     }
 
@@ -168,7 +168,7 @@ func (r *Resolver) Lookup(req *dns.Msg) (msg *dns.Msg) {
                     Qtype: q.Qtype,
                     Qclass: q.Qclass}
 
-                aChan, eChan = r.AnswerQuestion(question, true)
+                aChan, eChan = r.AnswerQuestion(question)
                 answers, errors = chansGather(aChan, eChan)
 
                 errored = errored || len(errors) > 0
@@ -238,7 +238,7 @@ func chansGather(rrsIn chan dns.RR, errsIn chan error) (rrs []dns.RR, errs []err
 // the way. The function will return immediately, and spawn off a bunch of goroutines
 // to do the work, when using this function one should use a WaitGroup to know when all work
 // has been completed.
-func (r *Resolver) AnswerQuestion(q dns.Question, resolveAliases bool) (answers chan dns.RR, errors chan error) {
+func (r *Resolver) AnswerQuestion(q dns.Question) (answers chan dns.RR, errors chan error) {
     answers = make(chan dns.RR)
     errors = make(chan error)
 

--- a/resolver.go
+++ b/resolver.go
@@ -143,79 +143,51 @@ func (r *Resolver) Lookup(req *dns.Msg) (msg *dns.Msg) {
     msg.Authoritative = true
     msg.RecursionAvailable = false // We're a nameserver, no recursion for you!
 
-    wait := sync.WaitGroup{}
-    answers := make(chan dns.RR)
-    errors := make(chan error)
+    answers := []dns.RR{}
+    errors := []error{}
+    errored := false
+
+    var aChan chan dns.RR
+    var eChan chan error
 
     if q.Qclass == dns.ClassINET {
-        r.AnswerQuestion(answers, errors, q, &wait)
+        aChan, eChan = r.AnswerQuestion(q, true)
+        answers, errors = chansGather(aChan, eChan)
     }
 
-    // Spawn a goroutine to close the channel as soon as all of the things
-    // are done. This allows us to ensure we'll wait for all workers to finish
-    // but allows us to collect up answers concurrently.
-    go func() {
-        wait.Wait()
-
+    errored = errored || len(errors) > 0
+    if len(answers) == 0 {
         // If we failed to find any answers, let's keep looking up the tree for
         // any wildcard domain entries.
-        if len(msg.Answer) == 0 {
-            parts := strings.Split(q.Name, ".")
-            for level := 1; level < len(parts); level++ {
-                domain := strings.Join(parts[level:], ".")
-                if len(domain) > 1 {
-                    question := dns.Question{
-                        Name: "*." + dns.Fqdn(domain),
-                        Qtype: q.Qtype,
-                        Qclass: q.Qclass}
+        parts := strings.Split(q.Name, ".")
+        for level := 1; level < len(parts); level++ {
+            domain := strings.Join(parts[level:], ".")
+            if len(domain) > 1 {
+                question := dns.Question{
+                    Name: "*." + dns.Fqdn(domain),
+                    Qtype: q.Qtype,
+                    Qclass: q.Qclass}
 
-                    r.AnswerQuestion(answers, errors, question, &wait)
+                aChan, eChan = r.AnswerQuestion(question, true)
+                answers, errors = chansGather(aChan, eChan)
 
-                    wait.Wait()
-                    if len(answers) > 0 {
-                        break;
-                    }
+                errored = errored || len(errors) > 0
+                if len(answers) > 0 {
+                    break;
                 }
             }
         }
-
-        debugMsg("Finished processing all goroutines, closing channels")
-        close(answers)
-        close(errors)
-    }()
+    }
 
     miss_counter := metrics.GetOrRegisterCounter("resolver.answers.miss", metrics.DefaultRegistry)
     hit_counter := metrics.GetOrRegisterCounter("resolver.answers.hit", metrics.DefaultRegistry)
     error_counter := metrics.GetOrRegisterCounter("resolver.answers.error", metrics.DefaultRegistry)
 
-    // Collect up all of the answers and any errors
-    done := 0
-    errors_count := 0
-
-    for done < 2 {
-        select {
-        case rr, ok := <-answers:
-            if ok {
-                rr.Header().Name = q.Name
-                msg.Answer = append(msg.Answer, rr)
-            } else {
-                done++
-            }
-        case err, ok := <-errors:
-            if ok {
-                // TODO(tarnfeld): Send special TXT records with a server error response code
-                debugMsg("Caught error ", err)
-                errors_count++
-            } else {
-                done++
-            }
-        }
-    }
-
-    if errors_count > 0 {
+    if errored {
+        // TODO(tarnfeld): Send special TXT records with a server error response code
         error_counter.Inc(1)
         msg.SetRcode(req, dns.RcodeServerFailure)
-    } else if len(msg.Answer) == 0 {
+    } else if len(answers) == 0 {
         soa := r.Authority(q.Name)
         miss_counter.Inc(1)
         msg.SetRcode(req, dns.RcodeNameError)
@@ -226,17 +198,49 @@ func (r *Resolver) Lookup(req *dns.Msg) (msg *dns.Msg) {
         }
     } else {
         hit_counter.Inc(1)
+        for _, rr := range answers {
+            rr.Header().Name = q.Name
+            msg.Answer = append(msg.Answer, rr)
+        }
     }
 
     return
 }
+
+
+func chansGather(rrsIn chan dns.RR, errsIn chan error) (rrs []dns.RR, errs []error) {
+    rrs = []dns.RR{}
+    errs = []error{}
+    done := 0
+    for done < 2 {
+        select {
+        case rr, ok := <-rrsIn:
+            if ok {
+                rrs = append(rrs, rr)
+            } else {
+                done++
+            }
+        case err, ok := <-errsIn:
+            if ok {
+                debugMsg("Caught error", err)
+                errs = append(errs, err)
+            } else {
+                done++
+            }
+        }
+    }
+    return rrs, errs
+}
+
 
 // AnswerQuestion takes two channels, one for answers and one for errors. It will answer the
 // given question writing the answers as dns.RR structures, and any errors it encounters along
 // the way. The function will return immediately, and spawn off a bunch of goroutines
 // to do the work, when using this function one should use a WaitGroup to know when all work
 // has been completed.
-func (r *Resolver) AnswerQuestion(answers chan dns.RR, errors chan error, q dns.Question, wg *sync.WaitGroup) {
+func (r *Resolver) AnswerQuestion(q dns.Question, resolveAliases bool) (answers chan dns.RR, errors chan error) {
+    answers = make(chan dns.RR)
+    errors = make(chan error)
 
     typeStr := strings.ToLower(dns.TypeToString[q.Qtype])
     type_counter := metrics.GetOrRegisterCounter("resolver.answers.type." + typeStr, metrics.DefaultRegistry)
@@ -245,8 +249,13 @@ func (r *Resolver) AnswerQuestion(answers chan dns.RR, errors chan error, q dns.
     debugMsg("Answering question ", q)
 
     if q.Qtype == dns.TypeANY {
+        wg := sync.WaitGroup{}
         wg.Add(len(converters))
-
+        go func(){
+            wg.Wait()
+            close(answers)
+            close(errors)
+        }()
         for rrType, _ := range converters {
             go func(rrType uint16) {
                 defer func() { recover() }()
@@ -263,11 +272,11 @@ func (r *Resolver) AnswerQuestion(answers chan dns.RR, errors chan error, q dns.
             }(rrType)
         }
     } else if _, ok := converters[q.Qtype]; ok {
-        wg.Add(1)
-
         go func() {
-            defer wg.Done()
-
+            defer func(){
+                close(answers)
+                close(errors)
+            }()
             records, err := r.LookupAnswersForType(q.Name, q.Qtype)
             if err != nil {
                 errors <- err
@@ -293,6 +302,8 @@ func (r *Resolver) AnswerQuestion(answers chan dns.RR, errors chan error, q dns.
             }
         }()
     }
+
+    return answers, errors
 }
 
 func (r *Resolver) LookupAnswersForType(name string, rrType uint16) (answers []dns.RR, err error) {

--- a/resolver_test.go
+++ b/resolver_test.go
@@ -391,6 +391,30 @@ func TestAnswerQuestionANY(t *testing.T) {
     }
 }
 
+func TestAnswerQuestionUnsupportedType(t *testing.T) {
+    // query for a type that we don't have support for (I tried to pick the most
+    // obscure rr type that the dns library supports and that we're unlikely to
+    // add support for)
+    query := new(dns.Msg)
+    query.SetQuestion("bar.disco.net.", dns.TypeEUI64)
+
+    answer := resolver.Lookup(query)
+
+    if len(answer.Answer) != 0 {
+        t.Error("Expected no answers, got ", len(answer.Answer))
+        t.Fatal()
+    }
+
+    if answer.Rcode != dns.RcodeNameError {
+        t.Error("Expected NXDOMAIN response code, got", dns.RcodeToString[answer.Rcode])
+        t.Fatal()
+    }
+
+    if len(answer.Ns) > 0 {
+        t.Error("Didn't expect any authority records")
+    }
+}
+
 func TestAnswerQuestionWildcardAAAANoMatch(t *testing.T) {
     resolver.etcdPrefix = "TestAnswerQuestionWildcardANoMatch/"
     client.Set("TestAnswerQuestionWildcardANoMatch/net/disco/bar/*/.AAAA", "::1", 0)


### PR DESCRIPTION
This removes the tightly-bound interplay of waitgroups and channel closes that `go test -race` was showing as a potential race.

- Add race flag to testing
- Simpler signature, no need to manage a waitgroup in multiple places
- Generally, only channel producers should be responsible for channel closing
- should be functionally identical:
    - the only difference I can see is that it's now impossible to get an error response that also has (partial) answers in. @tarnfeld do you see that as a problem?